### PR TITLE
Exception and warning handling for quantity data-type

### DIFF
--- a/kgtk/generator.py
+++ b/kgtk/generator.py
@@ -22,6 +22,7 @@ from etk.wikidata.value import (
     URLValue
 )
 from etk.knowledge_graph.node import LiteralType
+import warnings
 
 BAD_CHARS = [":", "&", ",", " ",
              "(", ")", "\'", '\"', "/", "\\", "[", "]", ";", "|"]
@@ -327,7 +328,7 @@ class TripleGenerator(Generator):
         return True
 
     def generate_normal_triple(
-            self, node1: str, property: str, node2: str, is_qualifier_edge: bool, e_id: str) -> bool:
+            self, node1: str, property: str, node2: str, is_qualifier_edge: bool, e_id: str, line_number: int) -> bool:
         if self.use_id:
             e_id = TripleGenerator.replace_illegal_string(e_id)
         entity = self._node_2_entity(node1)
@@ -389,7 +390,14 @@ class TripleGenerator(Generator):
         elif edge_type == QuantityValue:
             # +70[+60,+80]Q743895
             try:
-                res = self.quantity_pattern.match(node2).groups()
+                res = self.quantity_pattern.match(node2)
+                if self.warning and res == None:
+                    warnings.warn("Node2 [{}] at line [{}] is not a legal quantity. Skipping it.\n".format(
+                        node2, line_number))
+                    
+                    return False
+                res = res.groups()
+
             except:
                 raise KGTKException(
                     "Node2 [{}] at line [{}] is not a legal quantity.\n".format(
@@ -497,7 +505,7 @@ class TripleGenerator(Generator):
         else:
             if prop in self.prop_types:
                 success = self.generate_normal_triple(
-                    node1, prop, node2, is_qualifier_edge, e_id)
+                    node1, prop, node2, is_qualifier_edge, e_id, line_number)
             else:
                 raise KGTKException(
                     "property [{}]'s type is unknown at line [{}].\n".format(


### PR DESCRIPTION

**File:**[test_quantity.tsv.gz](https://github.com/usc-isi-i2/kgtk/files/5360233/test_quantity.tsv.gz)
### Description of the issue
There is a sample file attached which contains the edges where the `generate_wikidata_triples` generates an error and stops execution. The data-type of the edges in the file is quantity.

### Command Used and Screenshot of the error
**The Warning Parameter is not set to yes in the command**
`!time cat $chem_kgtk/test_quantity.tsv.gz | kgtk generate_wikidata_triples -ap aliases,alias -lp label \
                                                                                -dp description \
                                                                                -pf $chem_kgtk/properties.tsv \
                                                                                -n 3875 --debug \
                                                                                -gt yes -gz yes \
                                                                                > $chem_kgtk/without_warning_test_quantity.ttl`

![Screen Shot 2020-10-10 at 2 44 05 PM](https://user-images.githubusercontent.com/19925199/95665632-1f230f00-0b07-11eb-894e-742abeb19742.png)

**To solve this**: I passed the `line_number` parameter to `generate_normal_triple` function.

**The Warning Parameter is set to yes in the command**
`!time cat $chem_kgtk/test_quantity.tsv.gz | kgtk generate_wikidata_triples -ap aliases,alias -lp label \
                                                                                -dp description \
                                                                                -pf $chem_kgtk/properties.tsv \
                                                                                -n 50000 --debug \
                                                                                -gt yes -gz yes \
                                                                                -w yes -log $chem_kgtk/log.txt \
                                                                                > $chem_kgtk/test_quantity.ttl `


**Error**
![Screen Shot 2020-10-10 at 2 49 17 PM](https://user-images.githubusercontent.com/19925199/95665721-ce5fe600-0b07-11eb-8ff3-13217b144daa.png)

**To solve this**: I handled this in:
![Screen Shot 2020-10-10 at 2 52 35 PM](https://user-images.githubusercontent.com/19925199/95665830-c5234900-0b08-11eb-8104-281901ab1c0a.png)

Thank you!

