### PR TITLE
enhancement/docs/search: add Search box to KGTK documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,8 @@ markdown_extensions:
   - admonition
   - codehilite:
       guess_lang: false
+  - pymdownx.mark:
+      smart_mark: true
   - pymdownx.highlight
   - pymdownx.superfences
   - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,16 +64,26 @@ nav:
 theme:
   name: material
   logo: images/kgtk_logo_200x200.png
+  features:
+    - search.highlight
+    - search.share
+    - search.suggest
+
 extra_css:
   - stylesheets/extra.css
+
 repo_url: https://github.com/usc-isi-i2/kgtk
 
 plugins:
   - mknotebooks
+  - search:
+      prebuild_index: true
 
 markdown_extensions:
   - admonition
   - codehilite:
       guess_lang: false
+  - pymdownx.highlight
+  - pymdownx.superfences
   - toc:
       permalink: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ tox
 coverage
 coveralls
 mkdocs
-mkdocs-material
+mkdocs-material>=7.2.0
 mknotebooks
 ipykernel
 


### PR DESCRIPTION
Adds a Search box on KGTK documentation using [mkdocs-material](https://squidfunk.github.io/mkdocs-material/)'s built-in [search](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/) plugin. 

Known issue: The experimental [search.highlight](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-highlighting) feature is an [Insiders-only](https://squidfunk.github.io/mkdocs-material/insiders/#how-to-become-a-sponsor) feature for now. 