### PR TITLE
errant line break removed to fix markdown

### DIFF
--- a/docs/analysis/graph_embeddings.md
+++ b/docs/analysis/graph_embeddings.md
@@ -249,8 +249,8 @@ Line parsing:
 For easiest running, just give the input file and let it write its output to `output_embeddings.csv` at current folder
 
 
-``
-`kgtk graph-embeddings -i input_file.tsv  -o output_file.tsv
+```
+kgtk graph-embeddings -i input_file.tsv  -o output_file.tsv
 ```
 
 The output_file.tsv may look like:


### PR DESCRIPTION
A line break between backticks on line 252 caused the markdown to break.