### PR TITLE
Issue/623/kgtk cat small files

### DIFF
--- a/kgtk/cli/cat.py
+++ b/kgtk/cli/cat.py
@@ -158,10 +158,10 @@ def run(input_files: KGTKFiles,
 
     # Show the final option structures for debugging and documentation.
     if show_options:
-        print("--input-files %s" % " ".join((str(input_file_path) for input_file_path in input_file_paths)), file=error_file, flush=True)
-        print("--output-file=%s" % str(output_file_path), file=error_file, flush=True)
+        print("--input-files %s" % " ".join((repr(str(input_file_path)) for input_file_path in input_file_paths)), file=error_file, flush=True)
+        print("--output-file %s" % repr(str(output_file_path)), file=error_file, flush=True)
         if output_format is not None:
-            print("--output-format=%s" % output_format, file=error_file, flush=True)
+            print("--output-format %s" % repr(output_format), file=error_file, flush=True)
         if output_column_names is not None:
             print("--output-columns %s" % " ".join(output_column_names), file=error_file, flush=True)
         if old_column_names is not None:
@@ -170,13 +170,13 @@ def run(input_files: KGTKFiles,
             print("--new-columns %s" % " ".join(new_column_names), file=error_file, flush=True)
         print("--no-output-header %s" % str(no_output_header), file=error_file, flush=True)
         print("--pure-python %s" % str(pure_python), file=error_file, flush=True)
-        print("--fast-copy-min-size %d" % str(fast_copy_min_size), file=error_file, flush=True)
-        print("--bash-commahd %s" % str(bash_command), file=error_file, flush=True)
-        print("--bzip2-commahd %s" % str(bzip2_command), file=error_file, flush=True)
-        print("--cat-commahd %s" % str(cat_command), file=error_file, flush=True)
-        print("--gzip-commahd %s" % str(gzip_command), file=error_file, flush=True)
-        print("--tail-commahd %s" % str(tail_command), file=error_file, flush=True)
-        print("--xz-commahd %s" % str(xz_command), file=error_file, flush=True)
+        print("--fast-copy-min-size %d" % fast_copy_min_size, file=error_file, flush=True)
+        print("--bash-commahd %s" % repr(bash_command), file=error_file, flush=True)
+        print("--bzip2-commahd %s" % repr(bzip2_command), file=error_file, flush=True)
+        print("--cat-commahd %s" % repr(cat_command), file=error_file, flush=True)
+        print("--gzip-commahd %s" % repr(gzip_command), file=error_file, flush=True)
+        print("--tail-commahd %s" % repr(tail_command), file=error_file, flush=True)
+        print("--xz-commahd %s" % repr(xz_command), file=error_file, flush=True)
         reader_options.show(out=error_file)
         value_options.show(out=error_file)
         print("=======", file=error_file, flush=True)

--- a/kgtk/cli/cat.py
+++ b/kgtk/cli/cat.py
@@ -74,7 +74,8 @@ def add_arguments_extended(parser: KGTKArgumentParser, parsed_shared_args: Names
                         help="When True, use Python code. (default=%(default)s)",
                         type=optional_bool, nargs='?', const=True, default=KgtkCat.DEFAULT_PURE_PYTHON)
 
-    parser.add_argument('--fast-copy-min-size', dest='fast_copy_min_size', type=int, default=KgtkCat.DEFAULT_FAST_COPY_MIN_SIZE,
+    parser.add_argument('--fast-copy-min-size', dest='fast_copy_min_size', type=int,
+                        default=KgtkCat.DEFAULT_FAST_COPY_MIN_SIZE,
                         help='The minium number of bytes before using OS tools for fast copy (default=%(default)d).')
 
     parser.add_argument('--bash-command', dest='bash_command', type=str, default=KgtkCat.DEFAULT_BASH_COMMAND,
@@ -158,7 +159,8 @@ def run(input_files: KGTKFiles,
 
     # Show the final option structures for debugging and documentation.
     if show_options:
-        print("--input-files %s" % " ".join((repr(str(input_file_path)) for input_file_path in input_file_paths)), file=error_file, flush=True)
+        print("--input-files %s" % " ".join((repr(str(input_file_path)) for input_file_path in input_file_paths)),
+              file=error_file, flush=True)
         print("--output-file %s" % repr(str(output_file_path)), file=error_file, flush=True)
         if output_format is not None:
             print("--output-format %s" % repr(output_format), file=error_file, flush=True)

--- a/kgtk/join/kgtkcat.py
+++ b/kgtk/join/kgtkcat.py
@@ -21,6 +21,15 @@ from kgtk.value.kgtkvalueoptions import KgtkValueOptions
 
 @attr.s(slots=True, frozen=True)
 class KgtkCat():
+    DEFAULT_PURE_PYTHON: bool = False
+    DEFAULT_FAST_COPY_MIN_SIZE: int = 10000
+    DEFAULT_BASH_COMMAND: str = "bash"
+    DEFAULT_BZIP2_COMMAND: str = "bzip2"
+    DEFAULT_CAT_COMMAND: str = "cat"
+    DEFAULT_GZIP_COMMAND: str = "gzip"
+    DEFAULT_TAIL_COMMAND: str = "tail"
+    DEFAULT_XZ_COMMAND: str = "xz"
+    
     input_file_paths: typing.List[Path] = attr.ib()
     output_path: typing.Optional[Path] = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(Path)))
 
@@ -43,14 +52,15 @@ class KgtkCat():
                 default=None)
 
     no_output_header: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)
-    pure_python: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)
+    pure_python: bool = attr.ib(validator=attr.validators.instance_of(bool), default=DEFAULT_PURE_PYTHON)
+    fast_copy_min_size: int = attr.ib(validator=attr.validators.instance_of(int), default=DEFAULT_FAST_COPY_MIN_SIZE)
 
-    bash_command: str = attr.ib(validator=attr.validators.instance_of(str), default="bash")
-    bzip2_command: str = attr.ib(validator=attr.validators.instance_of(str), default="bzip2")
-    cat_command: str = attr.ib(validator=attr.validators.instance_of(str), default="cat")
-    gzip_command: str = attr.ib(validator=attr.validators.instance_of(str), default="gzip")
-    tail_command: str = attr.ib(validator=attr.validators.instance_of(str), default="tail")
-    xz_command: str = attr.ib(validator=attr.validators.instance_of(str), default="xz")
+    bash_command: str = attr.ib(validator=attr.validators.instance_of(str), default=DEFAULT_BASH_COMMAND)
+    bzip2_command: str = attr.ib(validator=attr.validators.instance_of(str), default=DEFAULT_BZIP2_COMMAND)
+    cat_command: str = attr.ib(validator=attr.validators.instance_of(str), default=DEFAULT_CAT_COMMAND)
+    gzip_command: str = attr.ib(validator=attr.validators.instance_of(str), default=DEFAULT_GZIP_COMMAND)
+    tail_command: str = attr.ib(validator=attr.validators.instance_of(str), default=DEFAULT_TAIL_COMMAND)
+    xz_command: str = attr.ib(validator=attr.validators.instance_of(str), default=DEFAULT_XZ_COMMAND)
 
     # TODO: find working validators:
     reader_options: typing.Optional[KgtkReaderOptions] = attr.ib(default=None)

--- a/kgtk/join/kgtkcat.py
+++ b/kgtk/join/kgtkcat.py
@@ -29,7 +29,7 @@ class KgtkCat():
     DEFAULT_GZIP_COMMAND: str = "gzip"
     DEFAULT_TAIL_COMMAND: str = "tail"
     DEFAULT_XZ_COMMAND: str = "xz"
-    
+
     input_file_paths: typing.List[Path] = attr.ib()
     output_path: typing.Optional[Path] = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(Path)))
 
@@ -287,13 +287,15 @@ class KgtkCat():
             total_input_file_size += input_file_path.stat().st_size
         if total_input_file_size < self.fast_copy_min_size:
             if self.verbose:
-                print("The total file size (%d) is less than the minimum for fast copies (%d)." % (total_input_file_size,
-                                                                                                   self.fast_copy_min_size),
+                print(("The total file size (%d) is less than the minimum "
+                       + "for fast copies (%d).") % (total_input_file_size,
+                                                     self.fast_copy_min_size),
                       file=self.error_file, flush=True)
             return False  # Take the slow path.
         if self.verbose:
-            print("The total file size (%d) meets the minimum for fast copies (%d)." % (total_input_file_size,
-                                                                                        self.fast_copy_min_size),
+            print(("The total file size (%d) meets the minimum "
+                   + "for fast copies (%d).") % (total_input_file_size,
+                                                 self.fast_copy_min_size),
                   file=self.error_file, flush=True)
 
         # Close the open files.


### PR DESCRIPTION
Add a threshold file size before using the system tools for fast copies.  Remove duplicate default values. Improve the --show-options feedback.